### PR TITLE
BSP CAN Driver

### DIFF
--- a/BSP/STM32F413/Inc/BSP_CAN.h
+++ b/BSP/STM32F413/Inc/BSP_CAN.h
@@ -6,6 +6,7 @@
 #include "stm32f4xx_hal.h"
 #include "FreeRTOS.h"
 #include "queue.h"
+#include "semphr.h"
 #include "CANMetaData.h"
 
 typedef struct CAN_TxPayload

--- a/BSP/STM32F413/Inc/BSP_CAN.h
+++ b/BSP/STM32F413/Inc/BSP_CAN.h
@@ -10,15 +10,15 @@
 
 typedef struct CAN_TxPayload
 {
-    CAN_TxHeaderTypeDef header;
-    uint32_t mailbox;
-    uint8_t data[8];
+    CAN_TxHeaderTypeDef header; /* can transmit header info */
+    uint32_t mailbox;           /* has which mailbox used when sent */
+    uint8_t data[8];            /* can data */
 } CAN_TxPayload_t;
 
 typedef struct CAN_RxPayload
 {
-    CAN_RxHeaderTypeDef header;
-    uint8_t data[8];
+    CAN_RxHeaderTypeDef header; /* can recieve header info */
+    uint8_t data[8];            /* can data */
 } CAN_RxPayload_t;
 
 /* handlers */

--- a/BSP/STM32F413/Inc/BSP_CAN.h
+++ b/BSP/STM32F413/Inc/BSP_CAN.h
@@ -1,0 +1,7 @@
+#include "stm32f4xx_hal.h"
+#include <stdint.h> 
+
+typedef struct Listener {
+    uint32_t id;
+    QueueHandle_t *queue;
+} Listener_t;

--- a/BSP/STM32F413/Inc/BSP_CAN.h
+++ b/BSP/STM32F413/Inc/BSP_CAN.h
@@ -1,18 +1,25 @@
 #ifndef __BSP_CAN_H__
 #define __BSP_CAN_H__
 
+#include <stdbool.h>
 #include "common.h"
 #include "stm32f4xx_hal.h"
 #include "FreeRTOS.h"
 #include "queue.h"
 #include "CANMetaData.h"
 
-/* communicators keep track of queues to use for communication*/
-typedef struct Communicator
+typedef struct CAN_TxPayload
 {
-    uint32_t id;
-    QueueHandle_t *queue;
-} Communicator_t;
+    CAN_TxHeaderTypeDef header;
+    uint32_t mailbox;
+    uint8_t data[8];
+} CAN_TxPayload_t;
+
+typedef struct CAN_RxPayload
+{
+    CAN_RxHeaderTypeDef header;
+    uint8_t data[8];
+} CAN_RxPayload_t;
 
 /* handlers */
 extern const CAN_HandleTypeDef *CarCAN;
@@ -20,9 +27,8 @@ extern const CAN_HandleTypeDef *LocalCAN;
 
 void CAN_CarCANInit(void);
 void CAN_LocalCANInit(void);
-void CAN_SetSpeaker(const CAN_HandleTypeDef *can, CANID_t id, QueueHandle_t *queue);
-void CAN_ClearSpeaker(const CAN_HandleTypeDef *can, CANID_t id);
-void CAN_SetListener(const CAN_HandleTypeDef *can, CANID_t id, QueueHandle_t *queue);
+bool CAN_Send(const CAN_HandleTypeDef *can, CAN_TxPayload_t payload, bool blocking);
+bool CAN_SetListener(const CAN_HandleTypeDef *can, CANID_t id, QueueHandle_t *queue);
 void CAN_ClearListener(const CAN_HandleTypeDef *can, CANID_t id);
 
 #endif /* __BSP_CAN_H__ */

--- a/BSP/STM32F413/Inc/BSP_CAN.h
+++ b/BSP/STM32F413/Inc/BSP_CAN.h
@@ -1,12 +1,18 @@
 #include <stdint.h> 
 #include "stm32f4xx_hal.h"
 
+/* rename for readability */
+#define CarCAN1 (CAN1)
+#define LocalCAN3 (CAN3)
+
+/* communicators keep track of queues to use for communication*/
 typedef struct Communicator {
     uint32_t id;
     QueueHandle_t *queue;
 } Communicator_t;
 
-// void CAN_Init(CAN_TypeDef *can);
+void CAN_CarCANInit(void);
+void CAN_LocalCANInit(void);
 void CAN_SetSpeaker(CAN_TypeDef *can, CANID_t id, QueueHandle_t *queue);
 void CAN_ClearSpeaker(CAN_TypeDef *can, CANID_t id);
 void CAN_SetListener(CAN_TypeDef *can, CANID_t id, QueueHandle_t *queue);

--- a/BSP/STM32F413/Inc/BSP_CAN.h
+++ b/BSP/STM32F413/Inc/BSP_CAN.h
@@ -1,9 +1,11 @@
-#include <stdint.h>
-#include "stm32f4xx_hal.h"
+#ifndef __BSP_CAN_H__
+#define __BSP_CAN_H__
 
-/* rename for readability */
-#define CarCAN1 (CAN1)
-#define LocalCAN3 (CAN3)
+#include "common.h"
+#include "stm32f4xx_hal.h"
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "CANMetaData.h"
 
 /* communicators keep track of queues to use for communication*/
 typedef struct Communicator
@@ -12,9 +14,15 @@ typedef struct Communicator
     QueueHandle_t *queue;
 } Communicator_t;
 
+/* handlers */
+extern const CAN_HandleTypeDef *CarCAN;
+extern const CAN_HandleTypeDef *LocalCAN;
+
 void CAN_CarCANInit(void);
 void CAN_LocalCANInit(void);
-void CAN_SetSpeaker(CAN_TypeDef *can, CANID_t id, QueueHandle_t *queue);
-void CAN_ClearSpeaker(CAN_TypeDef *can, CANID_t id);
-void CAN_SetListener(CAN_TypeDef *can, CANID_t id, QueueHandle_t *queue);
-void CAN_ClearListener(CAN_TypeDef *can, CANID_t id);
+void CAN_SetSpeaker(const CAN_HandleTypeDef *can, CANID_t id, QueueHandle_t *queue);
+void CAN_ClearSpeaker(const CAN_HandleTypeDef *can, CANID_t id);
+void CAN_SetListener(const CAN_HandleTypeDef *can, CANID_t id, QueueHandle_t *queue);
+void CAN_ClearListener(const CAN_HandleTypeDef *can, CANID_t id);
+
+#endif /* __BSP_CAN_H__ */

--- a/BSP/STM32F413/Inc/BSP_CAN.h
+++ b/BSP/STM32F413/Inc/BSP_CAN.h
@@ -1,4 +1,4 @@
-#include <stdint.h> 
+#include <stdint.h>
 #include "stm32f4xx_hal.h"
 
 /* rename for readability */
@@ -6,7 +6,8 @@
 #define LocalCAN3 (CAN3)
 
 /* communicators keep track of queues to use for communication*/
-typedef struct Communicator {
+typedef struct Communicator
+{
     uint32_t id;
     QueueHandle_t *queue;
 } Communicator_t;

--- a/BSP/STM32F413/Inc/BSP_CAN.h
+++ b/BSP/STM32F413/Inc/BSP_CAN.h
@@ -1,7 +1,13 @@
-#include "stm32f4xx_hal.h"
 #include <stdint.h> 
+#include "stm32f4xx_hal.h"
 
-typedef struct Listener {
+typedef struct Communicator {
     uint32_t id;
     QueueHandle_t *queue;
-} Listener_t;
+} Communicator_t;
+
+// void CAN_Init(CAN_TypeDef *can);
+void CAN_SetSpeaker(CAN_TypeDef *can, CANID_t id, QueueHandle_t *queue);
+void CAN_ClearSpeaker(CAN_TypeDef *can, CANID_t id);
+void CAN_SetListener(CAN_TypeDef *can, CANID_t id, QueueHandle_t *queue);
+void CAN_ClearListener(CAN_TypeDef *can, CANID_t id);

--- a/BSP/STM32F413/Src/BSP_CAN.c
+++ b/BSP/STM32F413/Src/BSP_CAN.c
@@ -1,0 +1,139 @@
+#include "BSP_CAN.h"
+#include "queue.h"
+#include "FreeRTOS.h"
+#include "CANMetaData.h"
+
+#define NUM_LISTENERS 16
+
+
+static CAN_HandleTypeDef CarCAN;
+static CAN_HandleTypeDef LocalCAN;
+
+static Listener_t CarListeners[NUM_LISTENERS] = {0};
+static Listener_t LocalListeners[NUM_LISTENERS] = {0};
+static CarListenersCount = 0;
+static LocalListenersCount = 0;
+
+void CAN_Init(CAN_TypeDef *can)
+{
+    // init init struct
+    // init gpio
+    // HAL_CAN_Start():
+}
+
+void CAN_Send(CAN_TypeDef *can, CANID_t id, QueueHandle_t *xQueue)
+{
+    
+}
+
+void CAN_SetListener(CAN_TypeDef *can, CANID_t id, QueueHandle_t *xQueue)
+{
+    /* set listeners depending on bus */
+    Listener_t *listeners = can == CAN1 ? CarListeners : LocalListeners;
+
+    /* find if listener is already set (linear set) */
+    for (int i = 0; i < NUM_LISTENERS; i++) {
+        if (listeners[i].id == id) {
+            /* replace if found (don't want duplicate ids) */
+            listeners[i].queue = xQueue;
+            return;
+        }
+    }
+
+    /* find empty listener spot */
+    for (int i = 0; i < NUM_LISTENERS; i++) {
+        if (listeners[i].queue == NULL) {
+            /* set if found */
+            listeners[i].id = id;
+            listeners[i].queue = xQueue;
+        }
+    }
+}
+
+void CAN_ClearListener(CAN_TypeDef *can, CANID_t id)
+{
+    /* set listeners depending on bus */
+    Listener_t *listeners = can == CAN1 ? CarListeners : LocalListeners;
+
+    /* clear listener if present */
+    for (int i = 0; i < NUM_LISTENERS; i++) {
+        if (listeners[i].id == id) {
+            listeners[i].id = 0;
+            listeners[i].queue = NULL;
+        }
+    }
+}
+
+void CAN1_RX0_IRQHandler()
+{
+    /* disable interrupts */
+    portENTER_CRITICAL();
+
+    /* check for any pending messages */
+    while(HAL_CAN_GetRxFifoFillLevel(CAN1, CAN_RX_FIFO0))
+    {
+        /* define data capture */
+        CAN_RxHeaderTypeDef pHeader;
+        uint8_t aData[8] = {0};
+
+        /* grab data from hardware rx fifo */
+        HAL_CAN_GetRxMessage(CAN1, CAN_RX_FIFO0, &pHeader, aData);
+
+        /* define queue to put data into */
+        QueueHandle_t *queue = NULL;
+
+        /* find listener (linear search) */
+        for (int i = 0; i < CarListeners; i++) {
+            if (CarListeners[i].id == pHeader.StdId) {
+
+                /* If found, then set queue to put data into */
+                queue = CarListeners[i].queue;
+            }
+        }
+
+        /* if listener found, put data into queue */
+        if (queue) {
+            xQueueSend(*queue, &aData, 0);
+        }
+    }
+
+    /* enable interrupts */
+    portEXIT_CRITICAL();
+}
+
+void CAN3_RX0_IRQHandler()
+{
+    /* disable interrupts */
+    portENTER_CRITICAL();
+
+    /* check for any pending messages */
+    while(HAL_CAN_GetRxFifoFillLevel(CAN3, CAN_RX_FIFO0))
+    {
+        /* define data capture */
+        CAN_RxHeaderTypeDef pHeader;
+        uint8_t aData[8] = {0};
+
+        /* grab data from hardware rx fifo */
+        HAL_CAN_GetRxMessage(CAN3, CAN_RX_FIFO0, &pHeader, aData);
+
+        /* define queue to put data into */
+        QueueHandle_t *queue = NULL;
+
+        /* find listener (linear search) */
+        for (int i = 0; i < LocalListeners; i++) {
+            if (LocalListeners[i].id == pHeader.StdId) {
+
+                /* If found, then set queue to put data into */
+                queue = LocalListeners[i].queue;
+            }
+        }
+
+        /* if listener found, put data into queue */
+        if (queue) {
+            xQueueSend(*queue, &aData, 0);
+        }
+    }
+
+    /* enable interrupts */
+    portEXIT_CRITICAL();
+}

--- a/BSP/STM32F413/Src/BSP_CAN.c
+++ b/BSP/STM32F413/Src/BSP_CAN.c
@@ -191,7 +191,7 @@ bool CAN_Send(const CAN_HandleTypeDef *can, CAN_TxPayload_t payload, bool blocki
         }
     }
 
-    /* if can tx is inactive, put payload into mailbox */
+    /* TODO: if can tx is inactive, put payload into mailbox */
 
     return ret;
 }

--- a/BSP/STM32F413/Src/BSP_CAN.c
+++ b/BSP/STM32F413/Src/BSP_CAN.c
@@ -1,14 +1,13 @@
 #include "BSP_CAN.h"
-#include "FreeRTOS.h"
-#include "queue.h"
-#include "CANMetaData.h"
 
 #define NUM_LISTENERS 16
 #define NUM_SPEAKERS 16
 
-/* used for initialization */
-static CAN_HandleTypeDef CarCAN = (CAN_HandleTypeDef){0};
-static CAN_HandleTypeDef LocalCAN = (CAN_HandleTypeDef){0};
+/* handlers */
+static CAN_HandleTypeDef _CarCAN = (CAN_HandleTypeDef){0};
+static CAN_HandleTypeDef _LocalCAN = (CAN_HandleTypeDef){0};
+const CAN_HandleTypeDef *CarCAN = &_CarCAN;
+const CAN_HandleTypeDef *LocalCAN = &_LocalCAN;
 
 /* array of communicators */
 static Communicator_t CarListeners[NUM_LISTENERS] = {0};
@@ -19,69 +18,69 @@ static Communicator_t LocalSpeakers[NUM_SPEAKERS] = {0};
 void CAN_CarCANInit(void)
 {
     /* init struct */
-    CarCAN.Instance = CarCAN1;
-    CarCAN.Init.Prescaler = 16;
-    CarCAN.Init.Mode = CAN_MODE_NORMAL;
-    CarCAN.Init.SyncJumpWidth = CAN_SJW_1TQ;
-    CarCAN.Init.TimeSeg1 = CAN_BS1_1TQ;
-    CarCAN.Init.TimeSeg2 = CAN_BS2_1TQ;
-    CarCAN.Init.TimeTriggeredMode = DISABLE;
-    CarCAN.Init.AutoBusOff = DISABLE;
-    CarCAN.Init.AutoWakeUp = DISABLE;
-    CarCAN.Init.AutoRetransmission = DISABLE;
-    CarCAN.Init.ReceiveFifoLocked = DISABLE;
-    CarCAN.Init.TransmitFifoPriority = DISABLE;
+    _CarCAN.Instance = CAN1;
+    _CarCAN.Init.Prescaler = 16;
+    _CarCAN.Init.Mode = CAN_MODE_NORMAL;
+    _CarCAN.Init.SyncJumpWidth = CAN_SJW_1TQ;
+    _CarCAN.Init.TimeSeg1 = CAN_BS1_1TQ;
+    _CarCAN.Init.TimeSeg2 = CAN_BS2_1TQ;
+    _CarCAN.Init.TimeTriggeredMode = DISABLE;
+    _CarCAN.Init.AutoBusOff = DISABLE;
+    _CarCAN.Init.AutoWakeUp = DISABLE;
+    _CarCAN.Init.AutoRetransmission = DISABLE;
+    _CarCAN.Init.ReceiveFifoLocked = DISABLE;
+    _CarCAN.Init.TransmitFifoPriority = DISABLE;
 
     /* initialize can perph */
-    if (HAL_CAN_Init(&CarCAN) != HAL_OK)
+    if (HAL_CAN_Init(&_CarCAN) != HAL_OK)
     {
         Error_Handler();
     }
 
     /* start can perph */
-    HAL_CAN_Start(&CarCAN);
+    HAL_CAN_Start(&_CarCAN);
 }
 
 void CAN_LocalCANInit(void)
 {
     /* init struct */
-    LocalCAN.Instance = LocalCAN3;
-    LocalCAN.Init.Prescaler = 16;
-    LocalCAN.Init.Mode = CAN_MODE_NORMAL;
-    LocalCAN.Init.SyncJumpWidth = CAN_SJW_1TQ;
-    LocalCAN.Init.TimeSeg1 = CAN_BS1_1TQ;
-    LocalCAN.Init.TimeSeg2 = CAN_BS2_1TQ;
-    LocalCAN.Init.TimeTriggeredMode = DISABLE;
-    LocalCAN.Init.AutoBusOff = DISABLE;
-    LocalCAN.Init.AutoWakeUp = DISABLE;
-    LocalCAN.Init.AutoRetransmission = DISABLE;
-    LocalCAN.Init.ReceiveFifoLocked = DISABLE;
-    LocalCAN.Init.TransmitFifoPriority = DISABLE;
+    _LocalCAN.Instance = CAN3;
+    _LocalCAN.Init.Prescaler = 16;
+    _LocalCAN.Init.Mode = CAN_MODE_NORMAL;
+    _LocalCAN.Init.SyncJumpWidth = CAN_SJW_1TQ;
+    _LocalCAN.Init.TimeSeg1 = CAN_BS1_1TQ;
+    _LocalCAN.Init.TimeSeg2 = CAN_BS2_1TQ;
+    _LocalCAN.Init.TimeTriggeredMode = DISABLE;
+    _LocalCAN.Init.AutoBusOff = DISABLE;
+    _LocalCAN.Init.AutoWakeUp = DISABLE;
+    _LocalCAN.Init.AutoRetransmission = DISABLE;
+    _LocalCAN.Init.ReceiveFifoLocked = DISABLE;
+    _LocalCAN.Init.TransmitFifoPriority = DISABLE;
 
     /* initialize can perph */
-    if (HAL_CAN_Init(&LocalCAN) != HAL_OK)
+    if (HAL_CAN_Init(&_LocalCAN) != HAL_OK)
     {
         Error_Handler();
     }
 
     /* start can perph */
-    HAL_CAN_Start(&LocalCAN);
+    HAL_CAN_Start(&_LocalCAN);
 }
 
 void HAL_CAN_MspInit(CAN_HandleTypeDef *canHandle)
 {
     GPIO_InitTypeDef GPIO_InitStruct = (GPIO_InitTypeDef){0};
 
-    if (canHandle->Instance == CarCAN1)
+    if (canHandle->Instance == CAN1)
     {
 
-        /* CarCAN1 clock enable */
+        /* CAN1 clock enable */
         __HAL_RCC_CAN1_CLK_ENABLE();
 
         /* GPIOA clock enable */
         __HAL_RCC_GPIOA_CLK_ENABLE();
 
-        /**CarCAN1 GPIO Configuration
+        /**CAN1 GPIO Configuration
         PA11     ------> CAN1_RX
         PA12     ------> CAN1_TX
         */
@@ -92,15 +91,15 @@ void HAL_CAN_MspInit(CAN_HandleTypeDef *canHandle)
         GPIO_InitStruct.Alternate = GPIO_AF9_CAN1;
         HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
     }
-    else if (canHandle->Instance == LocalCAN3)
+    else if (canHandle->Instance == CAN3)
     {
-        /* LocalCAN3 clock enable */
+        /* CAN3 clock enable */
         __HAL_RCC_CAN3_CLK_ENABLE();
 
         /* GPIOA clock enable */
         __HAL_RCC_GPIOA_CLK_ENABLE();
 
-        /**LocalCAN3 GPIO Configuration
+        /**CAN3 GPIO Configuration
         PA8     ------> CAN3_RX
         PA15     ------> CAN3_TX
         */
@@ -115,9 +114,9 @@ void HAL_CAN_MspInit(CAN_HandleTypeDef *canHandle)
 
 void HAL_CAN_MspDeInit(CAN_HandleTypeDef *canHandle)
 {
-    if (canHandle->Instance == CarCAN1)
+    if (canHandle->Instance == CAN1)
     {
-        /* CarCAN1 clock disable */
+        /* CAN1 clock disable */
         __HAL_RCC_CAN1_CLK_DISABLE();
 
         /**CAN1 GPIO Configuration
@@ -126,9 +125,9 @@ void HAL_CAN_MspDeInit(CAN_HandleTypeDef *canHandle)
         */
         HAL_GPIO_DeInit(GPIOA, GPIO_PIN_11 | GPIO_PIN_12);
     }
-    else if (canHandle->Instance == LocalCAN3)
+    else if (canHandle->Instance == CAN3)
     {
-        /* LocalCAN3 clock disable */
+        /* CAN3 clock disable */
         __HAL_RCC_CAN3_CLK_DISABLE();
 
         /**CAN3 GPIO Configuration
@@ -139,10 +138,10 @@ void HAL_CAN_MspDeInit(CAN_HandleTypeDef *canHandle)
     }
 }
 
-void CAN_SetSpeaker(CAN_TypeDef *can, CANID_t id, QueueHandle_t *queue)
+void CAN_SetSpeaker(const CAN_HandleTypeDef *canHandle, CANID_t id, QueueHandle_t *queue)
 {
     /* set speakers depending on bus */
-    Communicator_t speakers[] = can == CarCAN1 ? CarSpeakers : LocalSpeakers;
+    Communicator_t *speakers = (canHandle->Instance == CAN1) ? CarSpeakers : LocalSpeakers;
 
     /* find if speaker is already set (linear search) */
     for (int i = 0; i < NUM_SPEAKERS; i++)
@@ -166,10 +165,10 @@ void CAN_SetSpeaker(CAN_TypeDef *can, CANID_t id, QueueHandle_t *queue)
     }
 }
 
-void CAN_ClearSpeaker(CAN_TypeDef *can, CANID_t id)
+void CAN_ClearSpeaker(const CAN_HandleTypeDef *canHandle, CANID_t id)
 {
     /* set speakers depending on bus */
-    Communicator_t speakers[] = can == CarCAN1 ? CarSpeakers : LocalSpeakers;
+    Communicator_t *speakers = (canHandle->Instance == CAN1) ? CarSpeakers : LocalSpeakers;
 
     /* clear speaker if present */
     for (int i = 0; i < NUM_SPEAKERS; i++)
@@ -181,10 +180,10 @@ void CAN_ClearSpeaker(CAN_TypeDef *can, CANID_t id)
     }
 }
 
-void CAN_SetListener(CAN_TypeDef *can, CANID_t id, QueueHandle_t *queue)
+void CAN_SetListener(const CAN_HandleTypeDef *canHandle, CANID_t id, QueueHandle_t *queue)
 {
     /* set listeners depending on bus */
-    Communicator_t listeners[] = can == CarCAN1 ? CarListeners : LocalListeners;
+    Communicator_t *listeners = (canHandle->Instance == CAN1) ? CarListeners : LocalListeners;
 
     /* find if listener is already set (linear search) */
     for (int i = 0; i < NUM_LISTENERS; i++)
@@ -208,10 +207,10 @@ void CAN_SetListener(CAN_TypeDef *can, CANID_t id, QueueHandle_t *queue)
     }
 }
 
-void CAN_ClearListener(CAN_TypeDef *can, CANID_t id)
+void CAN_ClearListener(const CAN_HandleTypeDef *canHandle, CANID_t id)
 {
     /* set listeners depending on bus */
-    Communicator_t listeners[] = can == CarCAN1 ? CarListeners : LocalListeners;
+    Communicator_t *listeners = (canHandle->Instance == CAN1) ? CarListeners : LocalListeners;
 
     /* clear listener if present */
     for (int i = 0; i < NUM_LISTENERS; i++)
@@ -231,14 +230,14 @@ void CAN1_RX0_IRQHandler(void)
     /* TODO: acknowledge flag? */
 
     /* check for any pending messages */
-    while (HAL_CAN_GetRxFifoFillLevel(CarCAN1, CAN_RX_FIFO0))
+    while (HAL_CAN_GetRxFifoFillLevel(&_CarCAN, CAN_RX_FIFO0))
     {
         /* define data capture */
         CAN_RxHeaderTypeDef pHeader = (CAN_RxHeaderTypeDef){0};
         uint8_t aData[8] = {0};
 
         /* grab data from hardware rx fifo */
-        HAL_CAN_GetRxMessage(CarCAN1, CAN_RX_FIFO0, &pHeader, aData);
+        HAL_CAN_GetRxMessage(&_CarCAN, CAN_RX_FIFO0, &pHeader, aData);
 
         /* define queue to put data into */
         QueueHandle_t *queue = NULL;
@@ -276,14 +275,14 @@ void CAN3_RX0_IRQHandler(void)
     /* TODO: acknowledge flag? */
 
     /* check for any pending messages */
-    while (HAL_CAN_GetRxFifoFillLevel(LocalCAN3, CAN_RX_FIFO0))
+    while (HAL_CAN_GetRxFifoFillLevel(&_LocalCAN, CAN_RX_FIFO0))
     {
         /* define data capture */
         CAN_RxHeaderTypeDef pHeader = (CAN_RxHeaderTypeDef){0};
         uint8_t aData[8] = {0};
 
         /* grab data from hardware rx fifo */
-        HAL_CAN_GetRxMessage(LocalCAN3, CAN_RX_FIFO0, &pHeader, aData);
+        HAL_CAN_GetRxMessage(&_LocalCAN, CAN_RX_FIFO0, &pHeader, aData);
 
         /* define queue to put data into */
         QueueHandle_t *queue = NULL;
@@ -347,7 +346,7 @@ void CAN1_TX_IRQHandler(void)
         uint32_t pTxMailbox = 0;
 
         /* send message to mailbox */
-        HAL_CAN_AddTxMessage(CarCAN1, &pHeader, aData, &pTxMailbox);
+        HAL_CAN_AddTxMessage(&_CarCAN, &pHeader, aData, &pTxMailbox);
     }
 
     /* enable interrupts */
@@ -388,7 +387,7 @@ void CAN3_TX_IRQHandler(void)
         uint32_t pTxMailbox = 0;
 
         /* send message to mailbox */
-        HAL_CAN_AddTxMessage(LocalCAN3, &pHeader, aData, &pTxMailbox);
+        HAL_CAN_AddTxMessage(&_LocalCAN, &pHeader, aData, &pTxMailbox);
     }
 
     /* enable interrupts */

--- a/BSP/STM32F413/Src/BSP_CAN.c
+++ b/BSP/STM32F413/Src/BSP_CAN.c
@@ -113,6 +113,32 @@ void HAL_CAN_MspInit(CAN_HandleTypeDef *canHandle)
     }
 }
 
+void HAL_CAN_MspDeInit(CAN_HandleTypeDef *canHandle)
+{
+    if (canHandle->Instance == CarCAN1)
+    {
+        /* CarCAN1 clock disable */
+        __HAL_RCC_CAN1_CLK_DISABLE();
+
+        /**CAN1 GPIO Configuration
+        PA11     ------> CAN1_RX
+        PA12     ------> CAN1_TX
+        */
+        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_11 | GPIO_PIN_12);
+    }
+    else if (canHandle->Instance == LocalCAN3)
+    {
+        /* LocalCAN3 clock disable */
+        __HAL_RCC_CAN3_CLK_DISABLE();
+
+        /**CAN3 GPIO Configuration
+        PA8     ------> CAN3_RX
+        PA15     ------> CAN3_TX
+        */
+        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_8 | GPIO_PIN_15);
+    }
+}
+
 void CAN_SetSpeaker(CAN_TypeDef *can, CANID_t id, QueueHandle_t *queue)
 {
     /* set speakers depending on bus */

--- a/BSP/Tests/CAN.c
+++ b/BSP/Tests/CAN.c
@@ -6,18 +6,19 @@ uint8_t ucQueueStorage[8 * sizeof(char)];
 
 int main(void)
 {
-    /* setup queue */
-    QueueHandle_t xQueue = xQueueCreateStatic(
-        8,
-        sizeof(char),
-        ucQueueStorage,
-        &xQueueBuffer);
+    // /* setup queue */
+    // QueueHandle_t xQueue = xQueueCreateStatic(
+    //     8,
+    //     sizeof(char),
+    //     ucQueueStorage,
+    //     &xQueueBuffer);
 
-    /* init can */
-    CAN_CarCANInit();
+    // /* init can */
+    // CAN_CarCANInit();
 
-    /* set speaker */
-    CAN_SetSpeaker(CarCAN, 0x01, &xQueue);
+    // /* set speaker */
+    // CAN_SetSpeaker(CarCAN, 0x01, &xQueue);
+    return 0;
 }
 
 void Error_Handler(void)

--- a/BSP/Tests/CAN.c
+++ b/BSP/Tests/CAN.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include "BSP_CAN.h"
+
+StaticQueue_t xQueueBuffer = (StaticQueue_t){0};
+uint8_t ucQueueStorage[8 * sizeof(char)];
+
+int main(void)
+{
+    /* setup queue */
+    QueueHandle_t xQueue = xQueueCreateStatic(
+        8,
+        sizeof(char),
+        ucQueueStorage,
+        &xQueueBuffer);
+
+    /* init can */
+    CAN_CarCANInit();
+
+    /* set speaker */
+    CAN_SetSpeaker(CarCAN, 0x01, &xQueue);
+}
+
+void Error_Handler(void)
+{
+    __disable_irq();
+    while (1)
+    {
+    }
+}

--- a/BSP/Tests/CAN.c
+++ b/BSP/Tests/CAN.c
@@ -1,24 +1,120 @@
 #include <stdio.h>
 #include "BSP_CAN.h"
 
-StaticQueue_t xQueueBuffer = (StaticQueue_t){0};
-uint8_t ucQueueStorage[8 * sizeof(char)];
-
-int main(void)
-{
-    // /* setup queue */
-    // QueueHandle_t xQueue = xQueueCreateStatic(
-    //     8,
-    //     sizeof(char),
-    //     ucQueueStorage,
-    //     &xQueueBuffer);
+// int main(void)
+// {
+    // CAN_TxPayload_t payload = (CAN_TxPayload_t){
+    //     .header = (CAN_TxHeaderTypeDef){
+    //         .StdId = 0x32,
+    //     },
+    //     .data = {1, 2, 3, 4, 5, 6, 7, 8}
+    // };
 
     // /* init can */
     // CAN_CarCANInit();
 
-    // /* set speaker */
-    // CAN_SetSpeaker(CarCAN, 0x01, &xQueue);
-    return 0;
+    // /* send payload */
+    // CAN_Send(CarCAN, payload, false);
+
+//     while(1) {}
+// }
+
+CAN_HandleTypeDef     CanHandle;
+CAN_TxHeaderTypeDef   TxHeader;
+CAN_RxHeaderTypeDef   RxHeader;
+uint8_t               TxData[8];
+uint8_t               RxData[8];
+uint32_t              TxMailbox;
+
+int main(void)
+{
+    /*##-1- Configure the CAN peripheral #######################################*/
+    CanHandle.Instance = CAN1;
+    CanHandle.Init.Prescaler = 16;
+    CanHandle.Init.Mode = CAN_MODE_NORMAL;
+    CanHandle.Init.SyncJumpWidth = CAN_SJW_1TQ;
+    CanHandle.Init.TimeSeg1 = CAN_BS1_1TQ;
+    CanHandle.Init.TimeSeg2 = CAN_BS2_1TQ;
+    CanHandle.Init.TimeTriggeredMode = DISABLE;
+    CanHandle.Init.AutoBusOff = DISABLE;
+    CanHandle.Init.AutoWakeUp = DISABLE;
+    CanHandle.Init.AutoRetransmission = DISABLE;
+    CanHandle.Init.ReceiveFifoLocked = DISABLE;
+    CanHandle.Init.TransmitFifoPriority = DISABLE;
+    
+    if(HAL_CAN_Init(&CanHandle) != HAL_OK)
+    {
+        /* Initialization Error */
+        Error_Handler();
+    }
+
+    if (HAL_CAN_Start(&CanHandle) != HAL_OK)
+    {
+        /* Start Error */
+        Error_Handler();
+    }
+
+    TxHeader.StdId = 0x11;
+    TxHeader.RTR = CAN_RTR_DATA;
+    TxHeader.IDE = CAN_ID_STD;
+    TxHeader.DLC = 2;
+    TxHeader.TransmitGlobalTime = DISABLE;
+    TxData[0] = 0xCA;
+    TxData[1] = 0xFE;
+    
+    /* Request transmission */
+    if(HAL_CAN_AddTxMessage(&CanHandle, &TxHeader, TxData, &TxMailbox) != HAL_OK)
+    {
+        /* Transmission request Error */
+        Error_Handler();
+    }
+
+    while(1) {}
+}
+
+void HAL_CAN_MspInit(CAN_HandleTypeDef *canHandle)
+{
+    GPIO_InitTypeDef GPIO_InitStruct = (GPIO_InitTypeDef){0};
+
+    if (canHandle->Instance == CAN1)
+    {
+
+        /* CAN1 clock enable */
+        __HAL_RCC_CAN1_CLK_ENABLE();
+
+        /* GPIOA clock enable */
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+
+        /**CAN1 GPIO Configuration
+        PA11     ------> CAN1_RX
+        PA12     ------> CAN1_TX
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_11 | GPIO_PIN_12;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF9_CAN1;
+        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+    }
+    else if (canHandle->Instance == CAN3)
+    {
+        /* CAN3 clock enable */
+        __HAL_RCC_CAN3_CLK_ENABLE();
+
+        /* GPIOA clock enable */
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+
+        /**CAN3 GPIO Configuration
+        PA8     ------> CAN3_RX
+        PA15     ------> CAN3_TX
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_8 | GPIO_PIN_15;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF11_CAN3;
+        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+    }
 }
 
 void Error_Handler(void)

--- a/Util/Inc/common.h
+++ b/Util/Inc/common.h
@@ -31,5 +31,6 @@
 typedef void (*callback_t)(void);
 
 void print_float(char *str, float f);
+void Error_Handler(void);
 
 #endif


### PR DESCRIPTION
Requirements:
- Needs to allow dynamic creation of listeners and speakers on the CAN bus
- Use FreeRTOS queues

Enhancements:
- Binary search of communicators

To-Do Items:
- [ ] Make dummy init
- [ ] Make test file
- [ ] Check if builds
- [ ] Get it working
- [ ] Bring in BPS config init
- [ ] Get it working