### PR TITLE
Psom blink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: bsp_test
 test:
 ifdef test
 	$(MAKE) -C BSP -C STM32F413 -j TARGET=bsp PROJECT_DIR=../.. BUILD_DIR=../../Objects TEST=../Tests/$(test).c
@@ -5,11 +6,14 @@ else
 	$(error test is not set (e.g. make test test=HelloWorld))
 endif
 
-psom_test:
+.PHONY: psom_test
+test:
 ifdef psom_test
-	$(MAKE) -C BSP -C STM32F413 -j TARGET=Tests PROJECT_DIR=../.. BUILD_DIR=../../Objects TEST=../PeripheralSOM/$(psom_test).c
+	$(MAKE) -C BSP -C STM32F413 -j TARGET=Tests PROJECT_DIR=../.. BUILD_DIR=../../Objects TEST=../PeripheralSOM/$(test).c
+
 else
-	$(error PeripheralSOM test is not set (e.g. make psom_test psom_test=Heartbeat))
+	$(error PeripheralSOM test is not set (e.g. make psom_test test=Heartbeat))
+	
 endif
 
 # left commented as an example

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,13 @@ else
 	$(error test is not set (e.g. make test test=HelloWorld))
 endif
 
+psom_test:
+ifdef psom_test
+	$(MAKE) -C BSP -C STM32F413 -j TARGET=Tests PROJECT_DIR=../.. BUILD_DIR=../../Objects TEST=../PeripheralSOM/$(psom_test).c
+else
+	$(error PeripheralSOM test is not set (e.g. make psom_test psom_test=Heartbeat))
+endif
+
 # left commented as an example
 # project:
 # 	$(MAKE) -C BSP -C STM32F413 -j TARGET=bsp PROJECT_DIR=../.. BUILD_DIR=../../Objects TEST=../Tests/HelloWorld.c PROJECT_C_SOURCES="../../src/*.c ../../dogs/*.c"  PROJECT_C_INCLUDES=../../inc/

--- a/Tests/PeripheralSOM/Heartbeat.c
+++ b/Tests/PeripheralSOM/Heartbeat.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include "stm32f4xx_hal.h" // to do: change to L4
+
+GPIO_InitTypeDef gpio;
+
+int main(void){
+    printf("Hi! helllo there!!");
+    HAL_Init();
+
+    // Defines Pin A15 on the PeripheralSOM as an output
+    GPIO_InitTypeDef gpio;
+    gpio.Pin = GPIO_PIN_15;
+    gpio.Mode = GPIO_MODE_OUTPUT_PP; 
+    gpio.Pull = GPIO_NOPULL;
+    gpio.Speed = GPIO_SPEED_FREQ_LOW;
+
+    HAL_GPIO_Init(GPIOA, &gpio);
+
+    while (1) {
+        HAL_GPIO_TogglePin(GPIOA, GPIO_PIN_5);  // Toggle the LED
+        HAL_Delay(500);  // Delay for 500 milliseconds
+  }
+
+}


### PR DESCRIPTION
Adds functionality in the makefile to make psom tests
Adds the STM32L431 HAL (that is the chip we on the peripheralSOM)
Adds a test for the Leds to ensure that we can properly flash to the PeripheralSOM