### PR TITLE
requirements.txt instead of dockerized python package installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,8 @@ RUN apt-get install -y --no-install-recommends \
 # -----------------------------------------------------------------------------
 # Install Python
 # -----------------------------------------------------------------------------
-RUN pip install --no-cache-dir \
-    mkdocs \
-    pyserial
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
 FROM dev AS toolchain-cache
 # -----------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Dependencies for Python
+mkdocs
+pyserial

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Dependencies for Python
 mkdocs
 pyserial
+cantools


### PR DESCRIPTION
Moving the python dependencies needed for docker to new file that can be modified. Shows users what python packages are required by them while allowing docker to use this list to keep items consolidated.